### PR TITLE
Changed port that nancy listens to 8080

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -9,7 +9,7 @@
     {
         static void Main()
         {
-            var port = 8081;
+            var port = 8080;
             var nancyHost = new NancyHost(new Uri("http://0.0.0.0:" + port));
             nancyHost.Start();
 


### PR DESCRIPTION
The dockerfile exposes port 8080 but Nancy was configured to listen on 8081. This was corrected and curl gives back HTTP/1.1 200 OK now.
